### PR TITLE
fixed public ip validation

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -12,7 +12,9 @@ variable "public_ip_config" {
 
   validation {
     condition = (
-      var.virtual_machine_config.zone == null || var.public_ip_config.sku == "Standard"
+      var.public_ip_config == null || 
+      var.virtual_machine_config.zone == null || 
+      var.public_ip_config.sku == "Standard"
     )
     error_message = "If a zone is specified, the Public IP SKU must be set to 'Standard'."
   }


### PR DESCRIPTION
# Description

<!-- Please include a summary of changes and which issues are fixed -->

This change fixes a bug that involves using a zone in a virtual machine and declaring public_ip_config as null.

# Change overview (tick true):

- [ ] This introduces backward incompatible changes
- [ ] This adds a new backward compatible Feature
- [X] This fixes a Bug

# Version information: 

<!-- Look up the current/previous Version and update it below -->
- Previous Version: `2.0.0`
<!-- Update the version below, under which version you plan to release this PR. See Link on information how to increment the version number -->
- Next Version based on [Semantic Versioning](https://semver.org/#summary) (see above): `2.0.1`

# How Has This Been Tested?

<!-- Please list and describe tests that you performed -->
<!-- You should always do some tests! -->

- [X] Apply of all examples was successfull
- [X] Tested in new PEAC's subscription qas-SAPFI-01

# Checklist:

- [ ] I have run tests and documented them above
- [X] I have performed a self-review of my own code
- [ ] I have updated the documentation
- [ ] I have updated the CHANGELOG
- [X] There's no need to update the documentation
