### PR TITLE
Added new validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this module will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this module adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.0] - 2026-05-11
+
+### Added
+
+- Added new validation to the data disk variable "disk_mbps_read_write" and "disk_mbps_read_only" to support more Data Disk Types like "Premium", "PremiumV2" and "UltraSSD".
+
 ## [3.2.0] - 2026-03-05
 
 ### Added

--- a/variables.tf
+++ b/variables.tf
@@ -373,11 +373,25 @@ variable "data_disks" {
   validation {
     condition = alltrue([
       for o in var.data_disks : (
-        (o.disk_mbps_read_write == null ? true : (o.disk_mbps_read_write >= 125 && o.disk_mbps_read_write <= 750)) &&
-        (o.disk_mbps_read_only == null ? true : (o.disk_mbps_read_only >= 125 && o.disk_mbps_read_only <= 750))
+        (o.storage_account_type == "StandardSSD_LRS" &&
+          (o.disk_mbps_read_write == null ? true : (o.disk_mbps_read_write >= 125 && o.disk_mbps_read_write <= 750)) &&
+          (o.disk_mbps_read_only == null ? true : (o.disk_mbps_read_only >= 125 && o.disk_mbps_read_only <= 750))
+        ) || 
+        (o.storage_account_type == "Premium_LRS" &&
+          (o.disk_mbps_read_write == null ? true : (o.disk_mbps_read_write >= 125 && o.disk_mbps_read_write <= 900)) &&
+          (o.disk_mbps_read_only == null ? true : (o.disk_mbps_read_only >= 125 && o.disk_mbps_read_only <= 900))
+        ) || 
+        (o.storage_account_type == "PremiumV2_LRS" &&
+          (o.disk_mbps_read_write == null ? true : (o.disk_mbps_read_write >= 125 && o.disk_mbps_read_write <= 2000)) &&
+          (o.disk_mbps_read_only == null ? true : (o.disk_mbps_read_only >= 125 && o.disk_mbps_read_only <= 2000))
+        ) ||
+        (o.storage_account_type == "UltraSSD_LRS" &&
+          (o.disk_mbps_read_write == null ? true : (o.disk_mbps_read_write >= 125 && o.disk_mbps_read_write <= 10000)) &&
+          (o.disk_mbps_read_only == null ? true : (o.disk_mbps_read_only >= 125 && o.disk_mbps_read_only <= 10000))
+        )
       )
     ])
-    error_message = "disk_mbps_read_write and disk_mbps_read_only must be between 125 and 750 if set."
+    error_message = "disk_mbps_read_write and disk_mbps_read_only must be between 125 and 750 for StandardSSD, between 125 and 900 for Premium, between 125 and 2000 for PremiumV2 and between 125 and 10000 for UltraSSD, if set."
   }
   validation {
     condition = alltrue([

--- a/variables.tf
+++ b/variables.tf
@@ -373,14 +373,6 @@ variable "data_disks" {
   validation {
     condition = alltrue([
       for o in var.data_disks : (
-        (o.storage_account_type == "StandardSSD_LRS" &&
-          (o.disk_mbps_read_write == null ? true : (o.disk_mbps_read_write >= 125 && o.disk_mbps_read_write <= 750)) &&
-          (o.disk_mbps_read_only == null ? true : (o.disk_mbps_read_only >= 125 && o.disk_mbps_read_only <= 750))
-        ) || 
-        (o.storage_account_type == "Premium_LRS" &&
-          (o.disk_mbps_read_write == null ? true : (o.disk_mbps_read_write >= 125 && o.disk_mbps_read_write <= 900)) &&
-          (o.disk_mbps_read_only == null ? true : (o.disk_mbps_read_only >= 125 && o.disk_mbps_read_only <= 900))
-        ) || 
         (o.storage_account_type == "PremiumV2_LRS" &&
           (o.disk_mbps_read_write == null ? true : (o.disk_mbps_read_write >= 125 && o.disk_mbps_read_write <= 2000)) &&
           (o.disk_mbps_read_only == null ? true : (o.disk_mbps_read_only >= 125 && o.disk_mbps_read_only <= 2000))
@@ -388,7 +380,8 @@ variable "data_disks" {
         (o.storage_account_type == "UltraSSD_LRS" &&
           (o.disk_mbps_read_write == null ? true : (o.disk_mbps_read_write >= 125 && o.disk_mbps_read_write <= 10000)) &&
           (o.disk_mbps_read_only == null ? true : (o.disk_mbps_read_only >= 125 && o.disk_mbps_read_only <= 10000))
-        )
+        ) ||
+        (o.storage_account_type != "UltraSSD_LRS" && o.storage_account_type != "PremiumV2_LRS")
       )
     ])
     error_message = "disk_mbps_read_write and disk_mbps_read_only must be between 125 and 750 for StandardSSD, between 125 and 900 for Premium, between 125 and 2000 for PremiumV2 and between 125 and 10000 for UltraSSD, if set."


### PR DESCRIPTION
# Description

<!-- Please include a summary of changes and which issues are fixed -->
<!-- Example -->

- Added new validation to the data disk variable "disk_mbps_read_write" and "disk_mbps_read_only" to support more Data Disk Types like "Premium", "PremiumV2" and "UltraSSD".

# Change overview (tick true):

- [ ] This introduces backward incompatible changes
- [x] This adds a new backward compatible Feature
- [ ] This fixes a Bug

# Version information: 

<!-- Look up the current/previous Version and update it below -->
- Previous Version: 3.2.0
<!-- Update the version below, under which version you plan to release this PR. See Link on information how to increment the version number -->
- Next Version based on [Semantic Versioning](https://semver.org/#summary) (see above): 3.3.0

# How Has This Been Tested?

<!-- Please list and describe tests that you performed -->
<!-- You should always do some tests! -->

- [ ] Apply of all examples was successfull
- [x] Test with Basic example and multiple data disks

# Checklist:

- [x] I have run tests and documented them above
- [x] I have performed a self-review of my own code
- [x] I have updated the documentation
- [x] I have updated the CHANGELOG
